### PR TITLE
jEUR, EURS, EURT, WETH testnet deployments

### DIFF
--- a/.openzeppelin/unknown-80001.json
+++ b/.openzeppelin/unknown-80001.json
@@ -78,6 +78,26 @@
       "address": "0xae583E5E35c2bF14dE026941aA4f2593e646be60",
       "txHash": "0xde7be0a9272e4e5030bfd2c349d2c1bacedcee58a16c73ca334e3bb5ce0415bd",
       "kind": "uups"
+    },
+    {
+      "address": "0x4bf7737515EE8862306Ddc221cE34cA9d5C91200",
+      "txHash": "0x64087beae116a484f930f24720d3556aec896edc01889e3d7ed92b7460c7c00d",
+      "kind": "uups"
+    },
+    {
+      "address": "0x3Aa4345De8B32e5c9c14FC7146597EAf262Fd70E",
+      "txHash": "0x4d166f5e94286bba9cdb33eef8b171bc6a19cb93aecee402e4e3a675f77b1484",
+      "kind": "uups"
+    },
+    {
+      "address": "0x34A13C2D581efe6239b92F9a65c8BAa65dfdeBE9",
+      "txHash": "0x863da77b45bebd77ca0bdba25c19b0580541f51c5ce0b4416be051b33a773b07",
+      "kind": "uups"
+    },
+    {
+      "address": "0x910c98B3EAc2B4c3f6FdB81882bfd0161e507567",
+      "txHash": "0xafe2cf2ced58cb9287c4314031e6ff4aea17a6e3cb3a29e52e7c46c42572827d",
+      "kind": "uups"
     }
   ],
   "impls": {
@@ -5859,6 +5879,270 @@
           },
           "t_struct(Set)2278_storage": {
             "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "8a3e37c24e7d716e1fd1a5b040a6c673e502ecb39ca9ee8d5487901803de70bc": {
+      "address": "0x04aC83Cc0E3FCb416E190A7903f9772B6D2C0B02",
+      "txHash": "0x0c7d662f951f871d4090f2d266335ae05989a3221fbecad992a16595dc4eb484",
+      "layout": {
+        "storage": [
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC20",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:493"
+          },
+          {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "contract": "ERC20",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:495"
+          },
+          {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_uint256",
+            "contract": "ERC20",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:497"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_string_storage",
+            "contract": "ERC20",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:499"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_string_storage",
+            "contract": "ERC20",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:500"
+          },
+          {
+            "label": "_decimals",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_uint8",
+            "contract": "ERC20",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:501"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)35113_storage)",
+            "contract": "AccessControl",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:1177"
+          },
+          {
+            "label": "_revertMsg",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_string_storage",
+            "contract": "AccessControlMixin",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:1373"
+          },
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "8",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:67"
+          },
+          {
+            "label": "DOMAIN_SEPARATOR",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_bytes32",
+            "contract": "EIP712Domain",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:1566"
+          },
+          {
+            "label": "_nonces",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "Nonces",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:1580"
+          },
+          {
+            "label": "_authorizationStates",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_enum(AuthorizationState)35912))",
+            "contract": "GasAbstraction",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:1825"
+          },
+          {
+            "label": "_blacklisted",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "Blacklistable",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:2458"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_bool",
+            "contract": "Pausable",
+            "src": "contracts\\mock\\testnet\\MetaTxERC20Token.sol:2527"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "14",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\ERC1967\\ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "64",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\UUPSUpgradeable.sol:107"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(AuthorizationState)35912": {
+            "label": "enum GasAbstraction.AuthorizationState",
+            "members": [
+              "Unused",
+              "Used",
+              "Canceled"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_enum(AuthorizationState)35912))": {
+            "label": "mapping(address => mapping(bytes32 => enum GasAbstraction.AuthorizationState))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_enum(AuthorizationState)35912)": {
+            "label": "mapping(bytes32 => enum GasAbstraction.AuthorizationState)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)35113_storage)": {
+            "label": "mapping(bytes32 => struct AccessControl.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AddressSet)34869_storage": {
+            "label": "struct EnumerableSet.AddressSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)34683_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoleData)35113_storage": {
+            "label": "struct AccessControl.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_struct(AddressSet)34869_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(Set)34683_storage": {
+            "label": "struct EnumerableSet.Set",
             "members": [
               {
                 "label": "_values",

--- a/scripts/deploy/deployTestnetMetaTxToken.ts
+++ b/scripts/deploy/deployTestnetMetaTxToken.ts
@@ -1,0 +1,43 @@
+import { defaultAbiCoder, parseUnits } from "ethers/lib/utils";
+import { ethers, upgrades } from "hardhat"
+import { UChildAdministrableERC20 } from "../../typechain";
+
+async function main() {
+    const signers = await ethers.getSigners();
+    const Token = await ethers.getContractFactory("UChildAdministrableERC20");
+
+    const tokenName = "Testnet jEUR";
+    const tokenSymbol = "tjEUR";
+    const tokenDecimals = 18;
+
+    console.log("Deploying", tokenName);
+    let token = await upgrades.deployProxy(Token,
+        [
+            tokenName,
+            tokenSymbol,
+            18,
+            signers[0].address
+        ],
+        { initializer: 'initialize', kind: 'uups' }
+    ) as UChildAdministrableERC20;
+
+    await token.deployTransaction.wait();
+    console.log(tokenName, "upgradable deployed to:", token.address);
+
+    const amount = defaultAbiCoder.encode(["uint256"], [parseUnits("100000.0", tokenDecimals)]);
+    const mintTo = [signers[0].address];
+
+    // mint tokens
+    for (let i = 0; i < mintTo.length; i++) {
+        const dst = mintTo[i];
+        console.log("Minting", tokenSymbol, "to", dst);
+        await token.deposit(dst, amount);
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });


### PR DESCRIPTION
This PR introduces script for deploying tokens with metatx support and populates .openzeppelin file with new deployments on Mumbai testnet